### PR TITLE
fix 🐛: Union Pro support

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -63,10 +63,10 @@ def load_controlnet_flux_instantx(sd, controlnet_class, weight_dtype):
 
 def load_controlnet(full_path, weight_dtype):
     controlnet_data = comfy.utils.load_torch_file(full_path, safe_load=True)
-    if "controlnet_mode_embedder.fc.weight" in controlnet_data:
-        return load_controlnet_flux_instantx(controlnet_data, InstantXControlNetFlux, weight_dtype)
     if "controlnet_mode_embedder.weight" in controlnet_data:
         return load_controlnet_flux_instantx(controlnet_data, InstantXControlNetFluxFormat2, weight_dtype)
+    if "controlnet_mode_embedder.fc.weight" in controlnet_data:
+        return load_controlnet_flux_instantx(controlnet_data, InstantXControlNetFlux, weight_dtype)
     assert False, f"Only InstantX union controlnet supported. Could not find key 'controlnet_mode_embedder.fc.weight' in {full_path}"
 
 INSTANTX_UNION_CONTROLNET_TYPES = {


### PR DESCRIPTION
The condition needs to be "inverted" to work with https://huggingface.co/Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro

**without**
![image](https://github.com/user-attachments/assets/ab522c5d-23e3-4c59-b9bc-d05652332176)


**with**
![image](https://github.com/user-attachments/assets/d534f08e-e93c-47ba-94b6-af9b6c94a79d)

This is at strength 0.6, high strength still "breaks it" (not as bad as the first sample but it doesn't produce a great image)